### PR TITLE
Finish Vision api

### DIFF
--- a/app/assets/stylesheets/ads.scss
+++ b/app/assets/stylesheets/ads.scss
@@ -32,3 +32,11 @@
 	border-left: solid 5px #7db4e6;/*左線*/
 }
 
+.ai-label {
+	color: #fff;
+	font-size: 14px;
+	padding:5px;
+	background-color: #2d2d2d;
+	border-radius:5px;
+}
+

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -505,7 +505,7 @@ $color : #f26522;
       // padding: 0 0.3em;
       font-family: proxima-nova, monospace;
       transform: translate3d(0,$pad,0);
-      font-color: #fff;
+      color: #fff;
       font-size: 18px;
       background: #2d2d2d;
       display: block;

--- a/app/controllers/ad_clients/ads_controller.rb
+++ b/app/controllers/ad_clients/ads_controller.rb
@@ -10,25 +10,33 @@ class AdClients::AdsController < ApplicationController
     @ad = Ad.new
    end
 
-   def create
+  def create
     @ad = Ad.new(ad_params)
     @ad.ad_client_id = current_ad_client.id
     if @ad.save
-      redirect_to ad_client_ads_path
+      tags = Vision.get_image_data(@ad.ad_image)
+      tags.each do |tag|
+        @ad.tags.create(name: tag)
+      end
+      redirect_to ad_client_ad_path(@ad.ad_client_id,@ad.id)
     else
       render 'new'
     end
-   end
+  end
 
-   def edit
+  def show
+    @ad = Ad.find(params[:id])
+  end
+
+  def edit
    	@ad = Ad.find(params[:id])
-   end
+  end
 
-   def update
+  def update
    	@ad = Ad.find(params[:id])
    	@ad.update(ad_params)
    	redirect_to ad_client_ads_path
-   end
+  end
 
 
   private

--- a/app/models/ad.rb
+++ b/app/models/ad.rb
@@ -19,6 +19,7 @@ class Ad < ApplicationRecord
 	has_many :rooms
 	has_many :under_deals
 	has_many :favorites, dependent: :destroy
+	has_many :tags, dependent: :destroy
 
 	attachment :ad_image
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,3 @@
+class Tag < ApplicationRecord
+	belongs_to :ad
+end

--- a/app/views/ad_clients/ads/index.html.erb
+++ b/app/views/ad_clients/ads/index.html.erb
@@ -12,7 +12,7 @@
 				<table class="table" id="none-border">
 					<% @ads.each do |ad| %>
 						<td class="ad-index">
-							<%= link_to edit_ad_client_ad_path(current_ad_client.id,ad.id) do %>
+							<%= link_to ad_client_ad_path(ad.ad_client.id,ad.id) do %>
 								<%= attachment_image_tag ad,:ad_image, fallback: "no_image.jpg", class: "img_wrap",size:'200x160' %><br>
 							<%= ad.title %><% end %>&emsp;
 						<div id="favorites_buttons_<%= ad.id %>">

--- a/app/views/ad_clients/ads/show.html.erb
+++ b/app/views/ad_clients/ads/show.html.erb
@@ -8,8 +8,6 @@
       <%= render 'drivers/profile', driver: current_driver %>
       <%= render "drivers/sidebar", driver: current_driver %>
     <% end %><br>
-    <!-- ジャンル一覧 -->
-    <%= render "ads/genre_templete", genres: @genres %>
   </div>
   <div class="col-xs-9">
     <div class="ad-area">
@@ -52,33 +50,9 @@
             </td>
            </tr>
          </table>
+         <span class="link-button" ><%= link_to "編集する", edit_ad_client_ad_path(@ad.ad_client.id,@ad.id)  %>
       </div>
-       <%= form_for (@under_deal), url: under_deals_path, method: :post do |f| %>
-         <%= f.hidden_field :ad_id, :value => @ad.id %>
-         <%= f.hidden_field :driver_id, :value => current_driver.id %>
-          <section class="entry">
-            <a>
-              <%= f.submit "この広告に申し込む", :class => "text" %>
-              <span class="line -right"></span>
-              <span class="line -top"></span>
-              <span class="line -left"></span>
-              <span class="line -bottom"></span>
-            </a>
-          </section>
-       <% end %><br>
-        <section class="question">
-            <b>
-              <div class="text">
-              <%= link_to 'この広告のことで質問する', ad_chats_path(@ad.id) %>
-              </div>
-              <span class="line -right"></span>
-              <span class="line -top"></span>
-              <span class="line -left"></span>
-              <span class="line -bottom"></span>
-            </b>
-         </section>
-        <br>
     </div>
-    <span class="link-button" ><%= link_to "前の画面に戻る", ads_path  %>
+    <span class="link-button" ><%= link_to "広告一覧へ戻る", ad_client_ads_path(current_ad_client)  %>
   </div>
 </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,7 +10,7 @@ module PortfolioYagishita
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
-
+    config.paths.add 'lib', eager_load: true
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/db/migrate/20200510043246_create_tags.rb
+++ b/db/migrate/20200510043246_create_tags.rb
@@ -1,0 +1,10 @@
+class CreateTags < ActiveRecord::Migration[5.2]
+  def change
+    create_table :tags do |t|
+      t.string :name
+      t.integer :ad_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_03_043219) do
+ActiveRecord::Schema.define(version: 2020_05_10_043246) do
 
   create_table "ad_clients", force: :cascade do |t|
     t.string "email", null: false
@@ -183,6 +183,13 @@ ActiveRecord::Schema.define(version: 2020_05_03_043219) do
     t.integer "ad_client_id", null: false
     t.integer "driver_id", null: false
     t.integer "ad_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "name"
+    t.integer "ad_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/lib/vision.rb
+++ b/lib/vision.rb
@@ -1,0 +1,34 @@
+require 'base64'
+require 'json'
+require 'net/https'
+module Vision
+	class << self
+		def get_image_data(image_file)
+			api_url = "https://vision.googleapis.com/v1/images:annotate?key=#{ENV['GOOGLE_VISION_API_KEY']}"
+		# 画像をbase64にエンコード
+			base64_image = Base64.encode64(open("#{Rails.root}/tmp/uploads/store/#{image_file.id}").read)
+		# APIリクエスト用のJSONパラメータ
+			params = {
+				requests: [{
+					image: {
+						content: base64_image
+					},
+						features: [
+							{
+							type: 'LABEL_DETECTION'
+							}
+						]
+					}]
+				}.to_json
+		# Google Cloud Vision APIにリクエスト
+			uri = URI.parse(api_url)
+			https = Net::HTTP.new(uri.host, uri.port)
+			https.use_ssl = true
+			request = Net::HTTP::Post.new(uri.request_uri)
+			request['Content-Type'] = 'application/json'
+			response = https.request(request, params)
+		# APIレスポンス出力
+			JSON.parse(response.body)['responses'][0]['labelAnnotations'].pluck('description').take(3)
+		end
+	end
+end

--- a/test/fixtures/tags.yml
+++ b/test/fixtures/tags.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  ad_id: 1
+
+two:
+  name: MyString
+  ad_id: 1

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class TagTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Vision APIの実装
・tagモデルとテーブルの作成
・vision.rbの作成
・.envへvision api追加
・コントローラーのcreate処理の変更

広告主の広告管理フローにshowページを追加
・ad_client/ads/show.html追加
・indes→show→editのフローに各link_toを変更
