### PR TITLE
[Finish]#65 Issue 誤表示の修正2

### DIFF
--- a/app/assets/javascripts/channels/room.coffee
+++ b/app/assets/javascripts/channels/room.coffee
@@ -1,23 +1,23 @@
-App.room = App.cable.subscriptions.create "RoomChannel",
-  connected: ->
-    # Called when the subscription is ready for use on the server
+$ ->
+  App.room = App.cable.subscriptions.create { channel: "RoomChannel", room_id: $("input[name='chat']").data("room") },
+    connected: ->
+      # Called when the subscription is ready for use on the server
 
+    disconnected: ->
+      # Called when the subscription has been terminated by the server
 
-  disconnected: ->
-    # Called when the subscription has been terminated by the server
+    received: (data) ->
+      # Called when there's incoming data on the websocket for this channel'
+      if data["user_type"] == "0"
+     	  $('#chats').prepend("<span class='says'>"+"#{gon.driver_name}<br>"+data["message"]+"<br>"+data["created_at"]+"</span><br>");
+      else
+        $('#chats').prepend("<span class='says2'>"+"広告主<br>"+data["message"]+"</span><br>");
 
-  received: (data) ->
-    # Called when there's incoming data on the websocket for this channel
-    	if data["user_type"] == "0"
-     		$('#chats').prepend("<span class='says'>"+"#{gon.driver_name}<br>"+data["message"]+"</span><br>");
-     	else
-     		$('#chats').prepend("<span class='says2'>"+"広告主<br>"+data["message"]+"</span><br>");
-
-  speak: (message) ->
-    @perform 'speak', message: message
+    speak: (message) ->
+      @perform 'speak', message: message
 
 jQuery(document).on 'keypress', '[data-behavior~=room_speaker]', (event) ->
   if event.keyCode is 13
-    App.room.speak [event.target.value, $('[data-user').attr('data-user'), $('[data-room]').attr('data-room')]
+    App.room.speak [event.target.value, $('[data-user]').attr('data-user'), $('[data-room]').attr('data-room')]
     event.target.value = ''
     event.preventDefault()

--- a/app/channels/room_channel.rb
+++ b/app/channels/room_channel.rb
@@ -1,6 +1,6 @@
 class RoomChannel < ApplicationCable::Channel
   def subscribed
-  	stream_from "room_channel"
+  	stream_from "room_channel_#{params[:room_id]}"
   end
 
   def unsubscribed
@@ -10,7 +10,7 @@ class RoomChannel < ApplicationCable::Channel
   def speak(message)
   	chat = Chat.new(message: message['message'][0],user_type: message['message'][1].to_i,room_id: message['message'][2].to_i)
 		chat.save
-		ActionCable.server.broadcast 'room_channel', message: message['message'][0], user_type: message['message'][1]
+		ActionCable.server.broadcast "room_channel_#{message['message'][2].to_i}", message: message['message'][0], user_type: message['message'][1], created_at: chat.created_at.strftime("%Y/%m/%d %H:%M")
   end
 end
 

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -35,9 +35,9 @@
 	<div class="col-xs-11 col-offset-1">
 		<h4>チャットボックス</h4>
 			<% if driver_signed_in? %>
-				<input type="text" data-behavior="room_speaker" data-user="0" data-room="<%= @room.id %>" >
+				<input name="chat" type="text" data-behavior="room_speaker" data-user="0" data-room="<%= @room.id %>" >
 			<% else %>
-				<input type="text" data-behavior="room_speaker" data-user="1" data-room="<%= @room.id %>">
+				<input name="chat" type="text" data-behavior="room_speaker" data-user="1" data-room="<%= @room.id %>">
 			<% end %>
 			<%= render "chat", collection: @chats %>
 		</div>


### PR DESCRIPTION
・coffee.scriptの修正
broadcastするルームチャンネルに同じメソッド内でnewしたroom.idの情報を付与
・Room.channelの設定
subscriptionを作成する時にroom_idをinputタグから引き渡すように変更
subscriptions.create { channel: "RoomChannel", room_id: $("input[name='chat']").data("room") }