### PR TITLE
[Modify]取引フローの修正とレイアウトの変更

### DIFF
--- a/app/assets/stylesheets/ads.scss
+++ b/app/assets/stylesheets/ads.scss
@@ -7,6 +7,8 @@
 	heigth: 700px;
 	padding: 30px;
 	background: #2d2d2d;
+	box-shadow: 0 4px 15px rgba(0,0,0,.2);
+	border-radius:15px;
 }
 
 .ad-card{

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -44,6 +44,25 @@ footer{
   display: inline;
 }
 
+/* 各種会員登録画面 */
+
+.registration {
+  width: 100%;
+  height:100%;
+  background-color: #CCCCCC;
+}
+
+.registration-input {
+  width:100%;
+  height:100%;
+  padding:20px 30px;
+  background:#EEE;
+  margin:30px 0px;
+  box-shadow: 0 4px 15px rgba(0,0,0,.2);
+  border-radius:15px;
+}
+
+
 /* サイドバー */
 .sidebar-area{
   text-align: center;
@@ -91,6 +110,7 @@ h3{
 /* 運営側からのメッセージ */
 .notice{
   color: red;
+  margin-top: 15px;
 }
 
 /* テーブルの先頭の色を変更 */
@@ -377,7 +397,6 @@ $color : #f26522;
 
 .entry {
   background: #2d2d2d;
-  
   a {
     color: white;
     padding: $pad $extra;

--- a/app/assets/stylesheets/drivers.scss
+++ b/app/assets/stylesheets/drivers.scss
@@ -2,11 +2,3 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
-.deal-area{
-	witdh:100%;
-	height:100%;
-	padding:5px 10px;
-	background:#f5f5f5;
-	margin:30px 0px;
-	box-shadow: 0 4px 15px rgba(0,0,0,.2);
-}

--- a/app/assets/stylesheets/under_deals.scss
+++ b/app/assets/stylesheets/under_deals.scss
@@ -10,8 +10,19 @@ td {
 	margin-top: 5px
 }
 
+/* 広告情報 全体 */
+.deal-area{
+	width:100%;
+	height:100%;
+	padding:5px 10px;
+	background:#f5f5f5;
+	margin:30px 0px;
+	box-shadow: 0 4px 15px rgba(0,0,0,.2);
+}
+
+
 /* 1列目 広告情報 */
-#ad-area {
+#deal-ad-area {
 	width: 90%;
 	height: 350px;
 	background: #f5f5f5;

--- a/app/controllers/ad_clients_controller.rb
+++ b/app/controllers/ad_clients_controller.rb
@@ -7,7 +7,7 @@ class AdClientsController < ApplicationController
     @driver = current_driver
     deal_all = UnderDeal.includes(:ad).where(ads: {ad_client_id: current_ad_client.id} )
     @under_deals = deal_all.includes(:ad).where.not(work_status: 'finished')
-    @finish_deals = deal_all.includes(:ad,:deal_messages,:driver).references(:ad,:deal_messages,:driver).where(work_status: 'finished')
+    @finish_deals = deal_all.where(work_status: 'finished').or(deal_all.where(work_status: 'refuse')).or(deal_all.where(work_status: 'checked_refuse'))
     @rooms = Room.includes(:ad).where(ad_client: @ad_client)
   end
   # 非ログインユーザー/ドライバーから見た広告主一覧

--- a/app/controllers/under_deals_controller.rb
+++ b/app/controllers/under_deals_controller.rb
@@ -48,8 +48,6 @@ class UnderDealsController < ApplicationController
       @under_deal.update(under_deal_params)
       redirect_back(fallback_location: under_deal_path(@under_deal))
     elsif params[:completed]
-      @under_deal.work_status = 'completed'
-      @under_deal.save
       # deal_detail(取引情報)のテーブルへ振込先の情報保存
       @deal_detail = DealDetail.new(deal_detail_params)
       @transfer_infomation = TransferInformation.find(params[:detail][:transfer_information_id])
@@ -60,6 +58,8 @@ class UnderDealsController < ApplicationController
       @deal_detail.account_number = @transfer_infomation.account_number
       @deal_detail.account_name = @transfer_infomation.account_name
       if @deal_detail.save
+         @under_deal.work_status = 'completed'
+         @under_deal.save
          redirect_back(fallback_location: under_deal_path(@under_deal))
       else
         render 'show'

--- a/app/views/ad_clients/registrations/new.html.erb
+++ b/app/views/ad_clients/registrations/new.html.erb
@@ -1,74 +1,78 @@
-  <div class="row">
-    <div class="col-xs-6 col-md-offset-3">
-      <h3>新規広告主登録</h3>
+<div class="row">
+  <div class="registration">
+    <div class="col-xs-7 col-md-offset-2">
+      <div class="registration-input">
+        <h3>新規広告主登録</h3>
+          <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+            <%= render "devise/shared/error_messages", resource: resource %>
+            <table class="table" id="none-border">
+              <tr>
+                <td><%= f.label :会社名 %></td>
+                <td><%= f.text_field :company_name, autofocus: true, :size=>"40", autocomplete:"", placeholder:"会社名を入力", class: "form-control" %></td>
+              </tr>
+              <tr>
+                <td><%= f.label :会社名（カナ） %></td>
+                <td><%= f.text_field :company_name_kana, :size=>"40", autofocus: true, autocomplete:"", placeholder:"会社名のカナを入力", class: "form-control" %>
+                </td>
+              </tr>
+              <tr>
+                <td><%= f.label :代表取締役 %></td>
+                <td><%= f.text_field :ceo_name, autofocus: true, :size=>"40", autocomplete:"", placeholder:"代表取締役者名を入力", class: "form-control" %></td>
+              </tr>
+              <tr>
+                <td><%= f.label :代表取締役（カナ） %></td>
+                <td><%= f.text_field :ceo_name_kana, autofocus: true, :size=>"40", autocomplete:"", placeholder:"代表取締役者のフリガナを入力", class: "form-control" %></td>
+              </tr>
+              <tr>
+                <td><%= f.label :郵便番号 %></td>
+                <td><%= f.text_field :postal_code, autofocus: true, autocomplete:"", placeholder:"ハイフンなし", class: "form-control" %></td>
+              </tr>
+              <tr>
+                <td><%= f.label :住所 %></td>
+                <td><%= f.text_field :address,:size=>"60", autofocus: true, autocomplete:"", placeholder:"会社所在地を入力", class: "form-control" %></td>
+              </tr>
+              <tr>
+                <td><%= f.label :メールアドレス %></td>
+                <td><%= f.text_field :email, autofocus: true,:size=>"40", autocomplete:"", placeholder:"メールアドレスを入力", class: "form-control"%></td>
+              </tr>
+                <td><%= f.label :電話番号 %></td>
+                <td><%= f.text_field :telephone_number, autofocus: true, autocomplete:"",placeholder: "電話番号を入力", class: "form-control" %></td>
+              </tr>
+              <tr>
+                <td><%= f.label :登記簿藤本 %><br>※発行から3ヶ月以内</td>
+                <td><%= f.file_field :registry_image, id:"upload_file" %></td>
+              </tr>
+              <tr>
+                <td><%= f.label :パスワード %>
+                 <% if @minimum_password_length %>
+                   <em>( <%= @minimum_password_length %>文字以上 )</em>
+                 <% end %></td>
+                <td><%= f.password_field :password, autocomplete: "new-password", class: "form-control" %></td>
+              </tr>
+              <tr>
+                <td><%= f.label :パスワード（確認用） %></td>
+                <td><%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control" %></td>
+              </tr>
+              <tr>
+                <td><%= link_to "ご利用規約","https://drive.google.com/open?id=1S4yUlGV0eq2iKZGOVUhfwSGGeFXSo35_" %><br>
+                    必ずご一読、ご了承の上でご登録ください</td>
+              </tr>
+              <tr>
+                 <td><%= f.check_box :terms, checked:false, :as => :boolean %>利用規約に同意する</td>
+              </tr>
 
-      <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-        <%= render "devise/shared/error_messages", resource: resource %>
-        <table class="table" id="none-border">
-          <tr>
-            <td><%= f.label :会社名 %></td>
-            <td><%= f.text_field :company_name, autofocus: true, :size=>"40", autocomplete:"", placeholder:"会社名を入力", class: "form-control" %></td>
-          </tr>
-          <tr>
-            <td><%= f.label :会社名（カナ） %></td>
-            <td><%= f.text_field :company_name_kana, :size=>"40", autofocus: true, autocomplete:"", placeholder:"会社名のカナを入力", class: "form-control" %>
-            </td>
-          </tr>
-          <tr>
-            <td><%= f.label :代表取締役 %></td>
-            <td><%= f.text_field :ceo_name, autofocus: true, :size=>"40", autocomplete:"", placeholder:"代表取締役者名を入力", class: "form-control" %></td>
-          </tr>
-          <tr>
-            <td><%= f.label :代表取締役（カナ） %></td>
-            <td><%= f.text_field :ceo_name_kana, autofocus: true, :size=>"40", autocomplete:"", placeholder:"代表取締役者のフリガナを入力", class: "form-control" %></td>
-          </tr>
-          <tr>
-            <td><%= f.label :郵便番号 %></td>
-            <td><%= f.text_field :postal_code, autofocus: true, autocomplete:"", placeholder:"ハイフンなし", class: "form-control" %></td>
-          </tr>
-          <tr>
-            <td><%= f.label :住所 %></td>
-            <td><%= f.text_field :address,:size=>"60", autofocus: true, autocomplete:"", placeholder:"会社所在地を入力", class: "form-control" %></td>
-          </tr>
-          <tr>
-            <td><%= f.label :メールアドレス %></td>
-            <td><%= f.email_field :email, autofocus: true,:size=>"50", autocomplete:"", placeholder:"メールアドレスを入力", class: "form-control"%></td>
-          </tr>
-            <td><%= f.label :電話番号 %></td>
-            <td><%= f.text_field :telephone_number, autofocus: true, autocomplete:"",placeholder: "電話番号を入力", class: "form-control" %></td>
-          </tr>
-          <tr>
-            <td><%= f.label :登記簿藤本 %><br>※発行から3ヶ月以内</td>
-            <td><%= f.file_field :registry_image, id:"upload_file" %></td>
-          </tr>
-          <tr>
-            <td><%= f.label :パスワード %>
-             <% if @minimum_password_length %>
-               <em>( <%= @minimum_password_length %>文字以上 )</em>
-             <% end %></td>
-            <td><%= f.password_field :password, autocomplete: "new-password", class: "form-control" %></td>
-          </tr>
-          <tr>
-            <td><%= f.label :パスワード（確認用） %></td>
-            <td><%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control" %></td>
-          </tr>
-          <tr>
-            <td><%= link_to "ご利用規約","https://drive.google.com/open?id=1S4yUlGV0eq2iKZGOVUhfwSGGeFXSo35_" %><br>
-                必ずご一読、ご了承の上でご登録ください</td>
-          </tr>
-          <tr>
-             <td><%= f.check_box :terms, checked:false, :as => :boolean %>利用規約に同意する</td>
-          </tr>
-
-          <tr>
-            <td><%= f.submit "新規登録", class: "btn btn-primary btn-lg col-lg-offset-12" %></td>
-          </tr>
-        </table>
-     <% end %>
+              <tr>
+                <td><%= f.submit "新規登録", class: "btn btn-primary btn-lg col-lg-offset-12" %></td>
+              </tr>
+            </table>
+         <% end %>
+      </div>
     </div>
     <div class="col-xs-3">
       <h4>既に登録済みのご広告主は</h4>
         <%=link_to "こちら", new_ad_client_session_path %>からログインしてください。
     </div>
   </div>
+</div>
+
 

--- a/app/views/ads/show.html.erb
+++ b/app/views/ads/show.html.erb
@@ -12,7 +12,7 @@
     <%= render "ads/genre_templete", genres: @genres %>
   </div>
   <div class="col-xs-9">
-    <div class="deal-area">
+    <div class="ad-area">
       <div class="ad-card">
         <%= attachment_image_tag @ad, :ad_image, fallback: "no_image.jpg", size:'560x420' %>
           <table>
@@ -57,5 +57,4 @@
     </div>
     <span class="link-button" ><%= link_to "前の画面に戻る", ads_path  %></span>
   </div>
-</div>
 </div>

--- a/app/views/drivers/registrations/new.html.erb
+++ b/app/views/drivers/registrations/new.html.erb
@@ -1,69 +1,70 @@
-  <div class="row">
-    <div class="col-xs-6 col-md-offset-3">
+<div class="row">
+  <div class="col-xs-7 col-md-offset-2">
+    <div class="registration-input">
       <h3>新規ドライバー登録</h3>
-
-      <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-        <%= render "devise/shared/error_messages", resource: resource %>
-        <table class="table" id="none-border">
-          <tbody>
-            <tr>
-              <td><%= f.label :driver_name %></td>
-              <td><%= f.text_field :driver_name, autofocus: true, autocomplete:"", placeholder:"お名前を入力", class: "form-control" %></td>
-            </tr>
-            <tr>
-              <td><%= f.label :driver_name_kana %></td>
-              <td><%= f.text_field :driver_name_kana, autofocus: true, autocomplete:"", placeholder:"お名前のカナを入力", class: "form-control" %></td>
-            </tr>
-            <tr>
-              <td><%= f.label :postal_code %></td>
-              <td><%= f.text_field :postal_code, autofocus: true, autocomplete:"", placeholder:"ハイフンなし", class: "form-control" %></td>
-            </tr>
-            <tr>
-              <td><%= f.label :address %></td>
-              <td><%= f.text_field :address,:size=>"60", autofocus: true, autocomplete:"", placeholder:"ご住所を入力", class: "form-control" %></td>
-            </tr>
-            <tr>
-              <td><%= f.label :email %></td>
-              <td><%= f.email_field :email, autofocus: true,:size=>"50", autocomplete:"", placeholder:"メールアドレスを入力", class: "form-control"%></td>
-            </tr>
-              <td><%= f.label :telephone_number %></td>
-              <td><%= f.text_field :telephone_number, autofocus: true, autocomplete:"",placeholder: "電話番号を入力", class: "form-control" %></td>
-            </tr>
-            <tr>
-              <td><%= f.label :activity_area %></td>
-              <td>(例)東京都港区<%= f.text_field :activity_area, autofocus: true, placeholder:"都道府県と市町村名までを入力", class: "form-control"%></td>
-            </tr>
-            <tr>
-              <td><%= f.label :driver_license_image %></td>
-              <td><%= f.file_field :driver_license_image, id:"upload_file"%></td>
-            </tr>
-            <tr>
-              <td><%= f.label :password %>
-               <% if @minimum_password_length %>
-                 <em>( <%= @minimum_password_length %>文字以上 )</em>
-               <% end %></td>
-              <td><%= f.password_field :password, autocomplete: "new-password", class: "form-control" %></td>
-            </tr>
-            <tr>
-              <td><%= f.label :パスワード（確認用） %></td>
-              <td><%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control" %></td>
-            </tr>
-            <tr>
-              <td><%= link_to "ご利用規約","https://drive.google.com/open?id=1S4yUlGV0eq2iKZGOVUhfwSGGeFXSo35_" %><br>
-                  必ずご一読、ご了承の上でご登録ください</td>
-            </tr>
-            <tr>
-              <td><%= f.check_box :terms, checked:false, :as => :boolean %>利用規約に同意する</td>
-            </tr>
-            <tr>
-              <td><%= f.submit "新規登録", class: "btn btn-primary btn-lg col-lg-offset-12" %></td>
-            </tr>
-         </tbody>
-      </table>
-    <% end %>
-  </div>
-      <div class="col-xs-3">
-      <h4>既に登録済みのドライバーは</h4>
-        <%=link_to "こちら", new_driver_session_path %>からログインしてください。
+        <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+          <%= render "devise/shared/error_messages", resource: resource %>
+          <table class="table" id="none-border">
+            <tbody>
+              <tr>
+                <td><%= f.label :driver_name %></td>
+                <td><%= f.text_field :driver_name, autofocus: true, autocomplete:"", placeholder:"お名前を入力", class: "form-control" %></td>
+              </tr>
+              <tr>
+                <td><%= f.label :driver_name_kana %></td>
+                <td><%= f.text_field :driver_name_kana, autofocus: true, autocomplete:"", placeholder:"お名前のカナを入力", class: "form-control" %></td>
+              </tr>
+              <tr>
+                <td><%= f.label :postal_code %></td>
+                <td><%= f.text_field :postal_code, autofocus: true, autocomplete:"", placeholder:"ハイフンなし", class: "form-control" %></td>
+              </tr>
+              <tr>
+                <td><%= f.label :address %></td>
+                <td><%= f.text_field :address,:size=>"60", autofocus: true, autocomplete:"", placeholder:"ご住所を入力", class: "form-control" %></td>
+              </tr>
+              <tr>
+                <td><%= f.label :email %></td>
+                <td><%= f.text_field :email, autofocus: true,:size=>"50", autocomplete:"", placeholder:"メールアドレスを入力", class: "form-control"%></td>
+              </tr>
+                <td><%= f.label :telephone_number %></td>
+                <td><%= f.text_field :telephone_number, autofocus: true, autocomplete:"",placeholder: "電話番号を入力", class: "form-control" %></td>
+              </tr>
+              <tr>
+                <td><%= f.label :activity_area %></td>
+                <td>(例)東京都港区<%= f.text_field :activity_area, autofocus: true, placeholder:"都道府県と市町村名までを入力", class: "form-control"%></td>
+              </tr>
+              <tr>
+                <td><%= f.label :driver_license_image %></td>
+                <td><%= f.file_field :driver_license_image, id:"upload_file"%></td>
+              </tr>
+              <tr>
+                <td><%= f.label :password %>
+                 <% if @minimum_password_length %>
+                   <em>( <%= @minimum_password_length %>文字以上 )</em>
+                 <% end %></td>
+                <td><%= f.password_field :password, autocomplete: "new-password", class: "form-control" %></td>
+              </tr>
+              <tr>
+                <td><%= f.label :パスワード（確認用） %></td>
+                <td><%= f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control" %></td>
+              </tr>
+              <tr>
+                <td><%= link_to "ご利用規約","https://drive.google.com/open?id=1S4yUlGV0eq2iKZGOVUhfwSGGeFXSo35_" %><br>
+                    必ずご一読、ご了承の上でご登録ください</td>
+              </tr>
+              <tr>
+                <td><%= f.check_box :terms, checked:false, :as => :boolean %>利用規約に同意する</td>
+              </tr>
+              <tr>
+                <td><%= f.submit "新規登録", class: "btn btn-primary btn-lg col-lg-offset-12" %></td>
+              </tr>
+            </tbody>
+          </table>
+        <% end %>
     </div>
   </div>
+  <div class="col-xs-3">
+    <h4>既に登録済みのドライバーは</h4>
+      <%=link_to "こちら", new_driver_session_path %>からログインしてください。
+  </div>
+</div>

--- a/app/views/under_deals/_ad_info.html.erb
+++ b/app/views/under_deals/_ad_info.html.erb
@@ -1,5 +1,5 @@
 <div class="row">
-	<div id="ad-area">
+	<div id="deal-ad-area">
 		<div class="col-xs-5">
 			<%= attachment_image_tag ad, :ad_image, fallback: "no_image.jpg", size:'400x280' %>
 		</div>

--- a/app/views/under_deals/_apply_ad.html.erb
+++ b/app/views/under_deals/_apply_ad.html.erb
@@ -1,4 +1,4 @@
-  <% if driver_signed_in? %>
+<% if driver_signed_in? %>
     <% if check_apply.present? %>
       <div class="btn btn-default">現在、お申し込み中の広告がある為、新規のお申し込みができません</div>
     <% else %>

--- a/app/views/under_deals/_report_driver.html.erb
+++ b/app/views/under_deals/_report_driver.html.erb
@@ -38,12 +38,16 @@
 				<tr>
 					<td>
 						<% if under_deal.work_status == 'advertising' %>
-							<%= form_for under_deal, url:under_deal_path(under_deal), method: :patch do |f| %>
-								<%= fields_for deal_detail, url:under_deal_path(under_deal), method: :patch do |d| %>
-									<%= d.label :transfer_informations, "振込先の銀行口座を指定する" %>
-									<%= collection_select(:detail, :transfer_information_id, driver.transfer_informations.order("id DESC"),:id,:full_info) %>
+							<% if driver.transfer_informations.blank? %>
+								<p class="notice">口座情報が未登録です。<br>「ドライバー情報 編集」から登録してください。</p>
+							<% else %>
+								<%= form_for under_deal, url:under_deal_path(under_deal), method: :patch do |f| %>
+									<%= fields_for deal_detail, url:under_deal_path(under_deal), method: :patch do |d| %>
+										<%= d.label :transfer_informations, "振込先の銀行口座を指定する" %>
+										<%= collection_select(:detail, :transfer_information_id, driver.transfer_informations.order("id DESC"),:id,:full_info) %>
+									<% end %>
+									<%= f.submit "広告作業の完了報告", name:'completed', class: "btn btn-primary " %>
 								<% end %>
-							<%= f.submit "広告作業の完了報告", name:'completed', class: "btn btn-primary " %>
 							<% end %>
 						<% elsif under_deal.work_status == 'sent_kit' %>
 							<p class="btn btn-default report-cart-down" disabled="disabled">広告作業の完了報告をする</p>
@@ -53,11 +57,6 @@
 					</td>
 				</tr>
 			</table>
-			<% if under_deal.work_status == 'advertising' %>
-				<% if driver.transfer_informations.blank? %>
-					<p class="notice">口座情報が未登録です。<br>「ドライバー情報 編集」から登録してください。</p>
-				<% end %>
-			<% end %>
 		</div>
 		<div class="col-xs-3">
 			<table>
@@ -70,10 +69,12 @@
 							<%= form_for under_deal, url:under_deal_path(under_deal), method: :patch do |f| %>
 								<%= f.submit "広告主を評価", name:'rated', class: "btn btn-primary " %>
 							<% end %>
-						<% elsif under_deal.work_status == 'rated' or 'finished' %>
+						<% elsif under_deal.work_status == 'rated' %>
 							<p class="btn btn-default report-cart-down" disabled="disabled">評価済み</p>
+						<% elsif under_deal.work_status == 'finished' %>
+							<p class="btn btn-default report-cart-down" disabled="disabled">作業報告待ち</p>
 						<% else %>
-							<p class="btn btn-default report-cart-down" disabled="disabled">振り込み待ち</p>
+							<p class="btn btn-default report-cart-down" disabled="disabled">入金連絡待ち</p>
 						<% end %>
 					</td>
 				</tr>


### PR DESCRIPTION
＃会員登録画面のレイアウトの変更

＃取引フローの修正　
口座情報入力していない場合は画面にボタンを表示しない様に変更
・コントローラの修正
・ビューの変更

＃広告主ダッシュボードの変更
契約見送りと見送り了承を過去の取引一覧へ移動する様に変更
・コントローラの変更

